### PR TITLE
GH-3 [Bug]: Wrong repo_path variable

### DIFF
--- a/update_chart.py
+++ b/update_chart.py
@@ -8,11 +8,11 @@ from collections import OrderedDict
 import os
 
 # Environment variables
-repo_path = os.environ.get("GITHUB_EVENT_PATH")
+repo_path = os.environ.get("GITHUB_REPOSITORY")
 token = os.environ.get("INPUT_TOKEN")
 chart_file_path = (
-    "Chart.yaml"
-    or os.environ.get("INPUT_CHART_PATH"))
+    os.environ.get("INPUT_CHART_PATH")
+    or "Chart.yaml")
 new_version = os.environ.get("INPUT_NEW_VERSION")
 commit_message = (
     os.environ.get("INPUT_COMMIT_MESSAGE")
@@ -28,8 +28,8 @@ try:
     # Get Chart.yaml content
     try:
         content = repo.get_contents(chart_file_path)
-    except:
-        print(f"Chart.yaml not found in root directory of {repo_path}")
+    except Exception as e:
+        print(f"Chart.yaml not found at path '{chart_file_path}' in repository '{repo_path}': {e}")
         sys.exit(1)
 
     # Decode and parse YAML
@@ -46,7 +46,7 @@ try:
     # Create ordered dictionary with desired field order
     ordered_chart_data = OrderedDict()
     ordered_chart_data['apiVersion'] = chart_data.get('apiVersion')
-    ordered_chart_data['name'] = chart_data.get('name') 
+    ordered_chart_data['name'] = chart_data.get('name')
     ordered_chart_data['description'] = chart_data.get('description')
     ordered_chart_data['version'] = new_version
     ordered_chart_data['appVersion'] = new_version


### PR DESCRIPTION
# Pull Request

## Description
Changed variable from `GITHUB_EVENT_PATH` to `GITHUB_REPOSITORY`

## Related Issue
Fixes #3

## Type of Change
<!-- Mark the appropriate option with an "x" -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] CI/CD or workflow changes

## Testing
<!-- Describe the tests you ran to verify your changes -->
1. N/A

## Checklist
<!-- Mark all applicable items with an "x" -->
- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] This PR is ready for review

## Additional Notes
<!-- Add any other relevant information about the PR here -->